### PR TITLE
Turns off the building of submodules unless we're superbuilding.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.2)
 
 PROJECT(mongoAPI VERSION "0.1.0.0")
 
-option(BUILD_MODULES "Build submodules" ON )
+option(BUILD_MODULES "Build submodules" OFF )
 option(USE_SUPERBUILD "Use superbuild to pull in and build dependencies." ON)
 option(BUILD_TESTS "Build test libraries and excutables." ON)
 option(BUILD_TOOLS "Build interface tools." ON)


### PR DESCRIPTION
This keeps us from rebuilding libbson, MongoC, EP_mnmlstc_core, and MongoCXX twice during the build process.  If the project is being Superbuilt, it will still build them.  This changes the default when not doing Superbuild to not build them.